### PR TITLE
Exclude ANSI colors from character count

### DIFF
--- a/bin/transform-results.raku
+++ b/bin/transform-results.raku
@@ -1,6 +1,7 @@
 #!/usr/bin/env raku
 
 use JSON::Fast;
+use Terminal::ANSIColor;
 
 unit sub MAIN (
     Str:D :$test-file,
@@ -60,7 +61,13 @@ for from-json($tap-results.IO.slurp).List -> @part {
         when 'assert' {
             given %results<tests>[$i++] -> %test {
                 %test<name>   = @part[1]<name>;
-                %test<output> = $output.chars <= 500 ?? $output !! ($output.substr(0, 500) ~ '... Output was truncated. Please limit to 500 chars.') if $output;
+
+                if $output {
+                    %test<output> = colorstrip($output).chars <= 500
+                      ?? $output
+                      !! (colorstrip($output).substr(0, 500) ~ '... Output was truncated. Please limit to 500 chars.');
+                }
+
                 if @part[1]<ok> {
                     %test<status> = 'pass';
                 }


### PR DESCRIPTION
I've left the potential coloring of output present if the number of characters sans coloring falls below 500 (which could potentially end up being over 500, but I don't know if ANSI is to be considered part of the character count), else the color is stripped and output truncated.

Created in response to https://forum.exercism.org/t/increase-output/10487